### PR TITLE
fetching pets in chunks

### DIFF
--- a/api/PetStore.tsx
+++ b/api/PetStore.tsx
@@ -32,17 +32,38 @@ export const createPet = (user: User, pet: Pet) => {
 export const getMyPets = async (user: User) => {
   const db = firebase.firestore();
   if (user.pets) {
-    var petsRef = db
-      .collection("pets")
-      .where("id", "in", user.pets)
-      .get()
-      .then((snapshot) => {
-        let pets: Pet[] = [];
-        snapshot.forEach((doc) => {
-          pets.push(doc.data());
+    // Firebase only allows to query for 10 items with the `with - in` clause.
+    // To get around that we split the pets id into chunks of 10 and then combine
+    // the results at the end
+    const petChunks = chunk(user.pets, 10);
+    const promises = petChunks.map((petChunk: string[]) => {
+      return db
+        .collection("pets")
+        .where("id", "in", petChunk)
+        .get()
+        .then((snapshot) => {
+          let pets: Pet[] = [];
+          snapshot.forEach((doc) => {
+            pets.push(doc.data());
+          });
+          return pets;
         });
-        return pets;
-      });
-    return await petsRef;
+    });
+    const allPets = await Promise.all(promises);
+    return allPets.flat();
   } else return [];
 };
+
+/**
+ * A function that splits an array into chunks with the maximum size of "size"
+ * Example: chunk([1,2,3,4,5], 2) => [[1,2], [3,4], [5]]
+ */
+function chunk(array: any[], size: number) {
+  const chunked_arr = [];
+  let index = 0;
+  while (index < array.length) {
+    chunked_arr.push(array.slice(index, size + index));
+    index += size;
+  }
+  return chunked_arr;
+}


### PR DESCRIPTION
This PR fixes #17.

There are two possible ways, according to [this StackOverflow answer](https://stackoverflow.com/a/59257900) to the problem. Either fetch each document separately or batch the `for-in` into chunks of 10. I decided to try the latter and split the user pet list into chunks of 10, using the `chunk` function. The pets are then fetched in batches and combined before returning using the `flat` function. I kept the chunk function really general (using `any[]`) since we might want to use it later on for similar functions. 

I am not sure if there are any drawbacks to this, since I don't think that each user will have much more than 10-20 pets maximum so performance wise I believe this is okay.