### PR TITLE
Refresh petlist new pet

### DIFF
--- a/Core.tsx
+++ b/Core.tsx
@@ -12,7 +12,7 @@ import Navigation from "./navigation";
 import { User } from "./FirestoreModels";
 import { StateProvider, useStateContext } from "./globalState";
 import { ActionType } from "./reducer";
-import { getUser, userListener } from "./api/UserStore";
+import { getUser } from "./api/UserStore";
 
 export default function Core() {
   const isLoadingComplete = useCachedResources();
@@ -81,7 +81,7 @@ export default function Core() {
 
       return subscriber;
     }
-  }, []);
+  }, [user?.id]);
 
   if (!isLoadingComplete || initializing || !appIsReady) {
     return (

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -23,7 +23,7 @@ export default function Navigation({
   user,
 }: {
   colorScheme: ColorSchemeName;
-  user: User;
+  user: User | null;
 }) {
   return (
     <NavigationContainer

--- a/screens/MyProfileScreen.tsx
+++ b/screens/MyProfileScreen.tsx
@@ -132,15 +132,17 @@ export default function MyProfileScreen({ user }: { user: User }) {
     );
   };
   const fetchPets = async () => {
+    console.log("fetching");
     const result = await getMyPets(user).then((pets) => {
       return pets;
     });
+    console.log("results", result);
     setMyPets(result);
   };
 
   React.useEffect(() => {
     fetchPets();
-  }, []);
+  }, [user.pets]);
 
   return (
     <BaseContainer>

--- a/screens/MyProfileScreen.tsx
+++ b/screens/MyProfileScreen.tsx
@@ -132,11 +132,9 @@ export default function MyProfileScreen({ user }: { user: User }) {
     );
   };
   const fetchPets = async () => {
-    console.log("fetching");
     const result = await getMyPets(user).then((pets) => {
       return pets;
     });
-    console.log("results", result);
     setMyPets(result);
   };
 


### PR DESCRIPTION
This should fix issue #17.

I discovered a bug where the user subscriber didn't actually subscribe because it was only run on mount and then we could have scenarios where the user wasn't logged in. To fix it I added the user id as a dependency variable into the `useEffect` hook. This triggered the `onSnapshot` update when adding a new pet, followed by the dispatch of `USER_UPDATE`. The only thing after that was to trigger the fetchPets function by adding the `user.pets` as a dependency variable inside  `MyProfileScreen.tsx`.

I also added `User | null` in order to fix a TS issue that I saw while navigating the code